### PR TITLE
Fix: typographical error in README.md.

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ Node.js
 
 
 ```
-Npm install
+npm install
 ```
 
 ```


### PR DESCRIPTION
Installation instructions should read `npm install` and not `Npm install`, if I'm not mistaken.